### PR TITLE
feat: add responsive design to the title

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -48,3 +48,5 @@ BlankAmber [GitHub](https://github.com/BlankAmber)
 <br/>
 Ankush Tripathi [GitHub](https://github.com/ankushtripathii) | [LinkedIn](https://www.linkedin.com/in/ankush-tripathi-547008234/)
 <br/>
+Júlio Mazotti [GitHub](https://github.com/maztt) | [LinkedIn](https://www.linkedin.com/in/juliomasson)
+<br/>

--- a/index.css
+++ b/index.css
@@ -43,10 +43,12 @@ header>img {
 }
 .ml11 .text-wrapper {
     position: relative;
-    display: inline-block;
+    display: flex;
+    align-items: center;
     padding-top: 0.1em;
     padding-right: 0.05em;
     padding-bottom: 0.15em;
+
 }
 .ml11 .line {
     opacity: 0;

--- a/index.css
+++ b/index.css
@@ -130,3 +130,27 @@ footer > div > a {
     color: var(--secondary);
     text-decoration: underline;
 }
+
+@media screen and (max-width: 600px) {
+    span.letters {
+        font-size: 40px;
+    }
+}
+
+@media screen and (max-width: 415px) {
+    span.letters {
+        font-size: 30px;
+    }
+}
+
+@media screen and (max-width: 393px) {
+    span.letters {
+        font-size: 26px;
+    }
+}
+
+@media screen and (max-width: 320px) {
+    span.letters {
+        font-size: 18px;
+    }
+}

--- a/index.css
+++ b/index.css
@@ -24,30 +24,39 @@ header {
     display: flex;
     align-items: center;
 }
+
 header>img {
     width: 50px;
     height: 50px;
     margin-right: 15px;
 }
+
 #title {
     color: var(--secondary);
     font-size: 48px;
     margin-bottom: 20px;
     text-transform: uppercase;
 }
-/* css for title animation */
+
+
+/* TITLE ANIMATION */
+
 .ml11 {
     font-weight: 700;
     font-size: 3.5em;
     color: var(--secondary);
 }
+
 .ml11 .text-wrapper {
     position: relative;
-    display: inline-block;
+    display: flex;
+    align-items: center;
     padding-top: 0.1em;
     padding-right: 0.05em;
     padding-bottom: 0.15em;
+
 }
+
 .ml11 .line {
     opacity: 0;
     position: absolute;
@@ -57,16 +66,20 @@ header>img {
     background-color: var(--white);
     transform-origin: 0 50%;
 }
+
 .ml11 .line1 {
     top: 0;
     left: 0;
 }
+
 .ml11 .letter {
     display: inline-block;
     line-height: 1em;
 }
 
-/* Style the tab */
+
+/* TAB STYLING */
+
 .tab {
     width: 100%;
     margin-top: 20px;
@@ -75,6 +88,7 @@ header>img {
     border: 1px solid var(--primary);
     background-color: var(--white);
 }
+
 .tab button {
     background-color: inherit;
     border: none;
@@ -83,48 +97,89 @@ header>img {
     padding: 15px;
     color: var(--primary);
 }
+
 .tab button:hover {
     background-color: var(--gray);
 }
+
 .tab button.active {
     background-color: var(--primary);
     color: var(--secondary);
 }
+
 .tabcontent {
     display: none;
     padding: 5px;
 }
 
-/* style for table */
+
+/* TABLE STYLING */
+
 table {
     width: 100%;
     border-collapse: collapse;
     font-size: 18px;
 }
+
 td {
     padding: 10px;
     /* font-size: 20px; */
 }
+
 tr:hover {
     background-color: var(--secondary);
     color: var(--primary);
 }
+
 td:first-child {
     text-align: left;
 }
+
 tr:nth-child(1) {
     font-weight: 600;
 }
+
 a {
     text-decoration: none;
     color: var(--white);
 }
 
+
+/* FOOTER STYLING */
+
 footer {
     margin-top: 20px;
     color: var(--secondary);
 }
+
 footer > div > a {
     color: var(--secondary);
     text-decoration: underline;
+}
+
+
+/* RESPONSIVE ELEMENTS */
+
+@media screen and (max-width: 600px) {
+    span.letters {
+        font-size: 40px;
+    }
+}
+
+@media screen and (max-width: 415px) {
+    span.letters {
+        font-size: 30px;
+    }
+}
+
+@media screen and (max-width: 393px) {
+    span.letters {
+        font-size: 26px;
+    }
+}
+
+@media screen and (max-width: 320px) {
+    span.letters {
+        font-size: 18px;
+    }
 }

--- a/index.css
+++ b/index.css
@@ -24,23 +24,29 @@ header {
     display: flex;
     align-items: center;
 }
+
 header>img {
     width: 50px;
     height: 50px;
     margin-right: 15px;
 }
+
 #title {
     color: var(--secondary);
     font-size: 48px;
     margin-bottom: 20px;
     text-transform: uppercase;
 }
-/* css for title animation */
+
+
+/* TITLE ANIMATION */
+
 .ml11 {
     font-weight: 700;
     font-size: 3.5em;
     color: var(--secondary);
 }
+
 .ml11 .text-wrapper {
     position: relative;
     display: flex;
@@ -50,6 +56,7 @@ header>img {
     padding-bottom: 0.15em;
 
 }
+
 .ml11 .line {
     opacity: 0;
     position: absolute;
@@ -59,16 +66,20 @@ header>img {
     background-color: var(--white);
     transform-origin: 0 50%;
 }
+
 .ml11 .line1 {
     top: 0;
     left: 0;
 }
+
 .ml11 .letter {
     display: inline-block;
     line-height: 1em;
 }
 
-/* Style the tab */
+
+/* TAB STYLING */
+
 .tab {
     width: 100%;
     margin-top: 20px;
@@ -77,6 +88,7 @@ header>img {
     border: 1px solid var(--primary);
     background-color: var(--white);
 }
+
 .tab button {
     background-color: inherit;
     border: none;
@@ -85,51 +97,68 @@ header>img {
     padding: 15px;
     color: var(--primary);
 }
+
 .tab button:hover {
     background-color: var(--gray);
 }
+
 .tab button.active {
     background-color: var(--primary);
     color: var(--secondary);
 }
+
 .tabcontent {
     display: none;
     padding: 5px;
 }
 
-/* style for table */
+
+/* TABLE STYLING */
+
 table {
     width: 100%;
     border-collapse: collapse;
     font-size: 18px;
 }
+
 td {
     padding: 10px;
     /* font-size: 20px; */
 }
+
 tr:hover {
     background-color: var(--secondary);
     color: var(--primary);
 }
+
 td:first-child {
     text-align: left;
 }
+
 tr:nth-child(1) {
     font-weight: 600;
 }
+
 a {
     text-decoration: none;
     color: var(--white);
 }
 
+
+/* FOOTER STYLING */
+
 footer {
     margin-top: 20px;
     color: var(--secondary);
 }
+
 footer > div > a {
     color: var(--secondary);
     text-decoration: underline;
 }
+
+
+/* RESPONSIVE ELEMENTS */
 
 @media screen and (max-width: 600px) {
     span.letters {


### PR DESCRIPTION
For this Pull Request, we are implementing responsive design for the title element to ensure it fits better according to the user's screen size. Additionally, there is a slight horizontal improvement in the alignment of the logo and title.


I hope this is a helpful contribution, thanks for the opportunity!
Resolves #59 

`Previews below:`

__
### Horizontal alignment - Before/After:
![peopleschoice_align](https://github.com/aditeyaS/peoples-choice/assets/92126792/1181f534-f648-4382-8c93-11526fabe305)

__
### Title - Before:
![peopleschoice_title_before](https://github.com/aditeyaS/peoples-choice/assets/92126792/124aa592-9308-43d1-b4e1-a8c2b0992b90)


### Title - After:
![peopleschoice_title_after](https://github.com/aditeyaS/peoples-choice/assets/92126792/05ff43bd-fc81-4597-ac87-78f272050505)

